### PR TITLE
lib search path missing makes conftest execution fail in configure

### DIFF
--- a/build-auto.sh
+++ b/build-auto.sh
@@ -49,9 +49,9 @@ else
 fi
 
 if [ -e .staticlib ]; then
-    ./configure CPPFLAGS=-I${DVBTEE_ROOT}/usr/include/dvbpsi/ LDFLAGS="-L${DVBTEE_ROOT}/usr/lib/ -ldvbpsi" --enable-dvbpsibuild "$@" --enable-static
+    LD_LIBRARY_PATH=${DVBTEE_ROOT}/usr/lib ./configure CPPFLAGS=-I${DVBTEE_ROOT}/usr/include/dvbpsi/ LDFLAGS="-L${DVBTEE_ROOT}/usr/lib/ -ldvbpsi" --enable-dvbpsibuild "$@" --enable-static
 else
-    ./configure CPPFLAGS=-I${DVBTEE_ROOT}/usr/include/dvbpsi/ LDFLAGS="-L${DVBTEE_ROOT}/usr/lib/ -ldvbpsi" --enable-dvbpsibuild "$@"
+    LD_LIBRARY_PATH=${DVBTEE_ROOT}/usr/lib ./configure CPPFLAGS=-I${DVBTEE_ROOT}/usr/include/dvbpsi/ LDFLAGS="-L${DVBTEE_ROOT}/usr/lib/ -ldvbpsi" --enable-dvbpsibuild "$@"
 fi
 
 if [ -e .clean ]; then


### PR DESCRIPTION
libdvbpsi is installed locally to ./usr/lib, so binaries linked
to libs there need to know where the libs are when dynamically loaded on execution