### PR TITLE
Escape quotes dr 4d#15

### DIFF
--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -57,16 +57,15 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("lang", std::string((const char*)lang));
 
 	/* FIXME: we should escape these strings on output rather than on store */
-	char* escaped;
 	if (strchr((char*)name, '"')) {
-		escaped = escape_quotes((char*)name);
+		char* escaped = escape_quotes((char*)name);
 		set("name", std::string(escaped));
 		free(escaped);
 	} else {
 		set("name", std::string((char*)name));
 	}
 	if (strchr((char*)text, '"')) {
-		escaped = escape_quotes((char*)text);
+		char* escaped = escape_quotes((char*)text);
 		set("text", std::string(escaped));
 		free(escaped);
 	} else {

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -53,8 +53,8 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	get_descriptor_text(dr->i_text, dr->i_text_length, text);
 
 	set("lang", std::string((const char*)lang));
-	set("name", std::string((const char*)name));
-	set("text", std::string((const char*)text));
+	set("name", std::string(escape_quotes((char*)name)));
+	set("text", std::string(escape_quotes((char*)text)));
 
 	dPrintf("%s", toJson().c_str());
 

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -57,12 +57,21 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("lang", std::string((const char*)lang));
 
 	/* FIXME: we should escape these strings on output rather than on store */
-	char* escaped = escape_quotes((char*)name);
-	set("name", std::string(escaped));
-	free(escaped);
-	escaped = escape_quotes((char*)text);
-	set("text", std::string(escaped));
-	free(escaped);
+	char* escaped;
+	if (strchr((char*)name, '"')) {
+		escaped = escape_quotes((char*)name);
+		set("name", std::string(escaped));
+		free(escaped);
+	} else {
+		set("name", std::string((char*)name));
+	}
+	if (strchr((char*)text, '"')) {
+		escaped = escape_quotes((char*)text);
+		set("text", std::string(escaped));
+		free(escaped);
+	} else {
+		set("text", std::string((char*)text));
+	}
 
 	dPrintf("%s", toJson().c_str());
 

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -53,8 +53,12 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	get_descriptor_text(dr->i_text, dr->i_text_length, text);
 
 	set("lang", std::string((const char*)lang));
-	set("name", std::string(escape_quotes((char*)name)));
-	set("text", std::string(escape_quotes((char*)text)));
+	const char* escaped = escape_quotes((char*)name);
+	set("name", std::string(escaped));
+	free(escaped);
+	escaped = escape_quotes((char*)text);
+	set("text", std::string(escaped));
+	free(escaped);
 
 	dPrintf("%s", toJson().c_str());
 

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -55,6 +55,8 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	get_descriptor_text(dr->i_text, dr->i_text_length, text);
 
 	set("lang", std::string((const char*)lang));
+
+	/* FIXME: we should escape these strings on output rather than on store */
 	char* escaped = escape_quotes((char*)name);
 	set("name", std::string(escaped));
 	free(escaped);

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -19,6 +19,8 @@
  *
  *****************************************************************************/
 
+#include <stdlib.h>
+
 #include "desc_4d.h"
 
 #include "dvbpsi/dr_4d.h" /* short event descriptor */

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -55,7 +55,7 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	get_descriptor_text(dr->i_text, dr->i_text_length, text);
 
 	set("lang", std::string((const char*)lang));
-	const char* escaped = escape_quotes((char*)name);
+	char* escaped = escape_quotes((char*)name);
 	set("name", std::string(escaped));
 	free(escaped);
 	escaped = escape_quotes((char*)text);

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -287,3 +287,17 @@ char *url_decode(char *str) {
 	*pbuf = '\0';
 	return buf;
 }
+
+/* Returns a quote-escaped version of str */
+/* IMPORTANT: be sure to free() the returned string after use */
+char *escape_quotes(char *str) {
+	char *pstr = str, *buf = (char *)malloc(strlen(str) * 2 + 1), *pbuf = buf;
+	while (*pstr) {
+		if (*pstr == '"')
+			*pbuf++ = '\\';
+		*pbuf++ = *pstr;
+		pstr++;
+	}
+	*pbuf = '\0';
+	return buf;
+}

--- a/libdvbtee/functions.h
+++ b/libdvbtee/functions.h
@@ -86,5 +86,6 @@ time_t atsc_datetime_utc(uint32_t in_time);
 int decode_multiple_string(const uint8_t* data, uint8_t len, unsigned char* text, size_t sizeof_text);
 
 char *url_encode(char *str);
+char *escape_quotes(char *str);
 
 #endif /* __FUNCTIONS_H__ */


### PR DESCRIPTION
escape name & text in EIT descriptor 0x4d before storage for now -
this functionality should eventually be moved to the rendering portion rather than stored.