### PR TITLE
ETT improvements

### DIFF
--- a/libdvbtee/decode.cpp
+++ b/libdvbtee/decode.cpp
@@ -1447,8 +1447,13 @@ void decode::dump_epg_event(const decoded_vct_channel_t *channel, const decoded_
 	fprintf(stderr, "%04d-%02d-%02d %02d:%02d-%02d:%02d,%s\n",
 		tms.tm_year+1900, tms.tm_mon+1, tms.tm_mday,
 		tms.tm_hour, tms.tm_min, tme.tm_hour, tme.tm_min, name );
+
+	unsigned char message[4096];
+	const char* etm = (const char *)get_decoded_ett((channel->source_id << 16) | (event->event_id << 2) | 0x02, message, sizeof(message));
+	if (message[0])
+		fprintf(stderr, "\t%s\n", message);
+	
 	if (reporter) {
-		unsigned char message[4096];
 		reporter->epg_event((const char *)service_name,
 					 channel->chan_major, channel->chan_minor,
 					 physical_channel, channel->program,
@@ -1456,7 +1461,7 @@ void decode::dump_epg_event(const decoded_vct_channel_t *channel, const decoded_
 					 start,
 					 (end - start),
 					 (const char *)name,
-					 (const char *)get_decoded_ett((channel->source_id << 16) | (event->event_id << 2) | 0x02, message, sizeof(message)));
+					 (const char *)message);
 	}
 	return;
 }

--- a/libdvbtee/decode.h
+++ b/libdvbtee/decode.h
@@ -525,6 +525,7 @@ public:
 	void dump_eit_x(decode_report *reporter, uint8_t eit_x, uint16_t source_id = 0);
 	bool eit_x_complete(uint8_t current_eit_x);
 	bool got_all_eit(int limit = -1);
+	bool got_all_ett();
 
 	void dump_epg(decode_report *reporter);
 

--- a/libdvbtee/parse.cpp
+++ b/libdvbtee/parse.cpp
@@ -710,7 +710,13 @@ parse::parse()
   , ts_id(0)
   , epg_mode(false)
   , scan_mode(false)
-  , dont_collect_ett(true)
+  , dont_collect_ett(
+#if ETT
+	  false
+#else
+	  true
+#endif
+	  )
   , has_pat(false)
   , has_mgt(false)
   , has_vct(false)

--- a/libdvbtee/parse.cpp
+++ b/libdvbtee/parse.cpp
@@ -1158,7 +1158,16 @@ bool parse::is_psip_ready()
 
 bool parse::is_epg_ready()
 {
-	return ((is_psip_ready()) && ((decoders.count(get_ts_id()) && (decoders[get_ts_id()].got_all_eit(eit_collection_limit)))));
+	if (!is_psip_ready()) return false;
+	if (!decoders.count(get_ts_id())) return false;
+	decode& d=decoders[get_ts_id()];
+	if (!d.got_all_eit(eit_collection_limit)) return false;
+#if ETT
+#if 1
+	if (!d.got_all_ett()) return false;
+#endif
+#endif
+	return true;
 }
 
 int parse::add_output(void* priv, stream_callback callback)


### PR DESCRIPTION
So my eventual goal is to use ETTs for duplicate recording detection. Out of all the EPG tools I could find, it seems as if dvbtee is the closest to this goal. I was able to get a proof-of-concept working (in these patches) inside the ETT ifdef, by pulling ETTs into -E output via dump_epg_event, and (crudely) blocking completion of -E until all ETTs are accounted for.

This causes execution time under -E to balloon to 2-5 minutes on KLRU-HD because the ETTs for higher EITs are transmitted infrequently.
