### PR TITLE
fix header inclusion when building an app that depends on libdvbtee

### DIFF
--- a/dvbtee/Makefile.am
+++ b/dvbtee/Makefile.am
@@ -1,4 +1,5 @@
 AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee_server -D__STDC_FORMAT_MACROS
+AM_CXXFLAGS += -I../libdvbtee/decode/table
 
 bin_PROGRAMS = dvbtee
 dvbtee_SOURCES = dvbtee.cpp

--- a/dvbtee/Makefile.am
+++ b/dvbtee/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee_server -D__STDC_FORMAT_MACROS
-AM_CXXFLAGS += -I../libdvbtee/decode -I../libdvbtee/decode/table
+AM_CXXFLAGS += -I../libdvbtee/decode -I../libdvbtee/decode/table -I../libdvbtee/decode/descriptor
 
 bin_PROGRAMS = dvbtee
 dvbtee_SOURCES = dvbtee.cpp

--- a/dvbtee/Makefile.am
+++ b/dvbtee/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee_server -D__STDC_FORMAT_MACROS
-AM_CXXFLAGS += -I../libdvbtee/decode/table
+AM_CXXFLAGS += -I../libdvbtee/decode -I../libdvbtee/decode/table
 
 bin_PROGRAMS = dvbtee
 dvbtee_SOURCES = dvbtee.cpp

--- a/examples/parser_example/Makefile.am
+++ b/examples/parser_example/Makefile.am
@@ -1,4 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee -I../../libdvbtee_server
+AM_CXXFLAGS += -I../../libdvbtee/decode/table
 
 bin_PROGRAMS = dvbtee-parser
 dvbtee_parser_SOURCES = parser.cpp

--- a/examples/parser_example/Makefile.am
+++ b/examples/parser_example/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee -I../../libdvbtee_server
-AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table
+AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table -I../../libdvbtee/decode/descriptor
 
 bin_PROGRAMS = dvbtee-parser
 dvbtee_parser_SOURCES = parser.cpp

--- a/examples/parser_example/Makefile.am
+++ b/examples/parser_example/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee -I../../libdvbtee_server
-AM_CXXFLAGS += -I../../libdvbtee/decode/table
+AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table
 
 bin_PROGRAMS = dvbtee-parser
 dvbtee_parser_SOURCES = parser.cpp

--- a/examples/server_example/Makefile.am
+++ b/examples/server_example/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee -I../../libdvbtee_server
-AM_CXXFLAGS += -I../../libdvbtee/decode/table
+AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table
 
 bin_PROGRAMS = dvbtee-server
 dvbtee_server_SOURCES = server.cpp

--- a/examples/server_example/Makefile.am
+++ b/examples/server_example/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee -I../../libdvbtee_server
-AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table
+AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table -I../../libdvbtee/decode/descriptor
 
 bin_PROGRAMS = dvbtee-server
 dvbtee_server_SOURCES = server.cpp

--- a/examples/server_example/Makefile.am
+++ b/examples/server_example/Makefile.am
@@ -1,4 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee -I../../libdvbtee_server
+AM_CXXFLAGS += -I../../libdvbtee/decode/table
 
 bin_PROGRAMS = dvbtee-server
 dvbtee_server_SOURCES = server.cpp

--- a/examples/walk_hls/Makefile.am
+++ b/examples/walk_hls/Makefile.am
@@ -1,4 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee
+AM_CXXFLAGS += -I../../libdvbtee/decode/table
 
 bin_PROGRAMS = walk-hls
 walk_hls_SOURCES = main.cpp hlsinput.cpp

--- a/examples/walk_hls/Makefile.am
+++ b/examples/walk_hls/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee
-AM_CXXFLAGS += -I../../libdvbtee/decode/table
+AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table
 
 bin_PROGRAMS = walk-hls
 walk_hls_SOURCES = main.cpp hlsinput.cpp

--- a/examples/walk_hls/Makefile.am
+++ b/examples/walk_hls/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../../libdvbtee
-AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table
+AM_CXXFLAGS += -I../../libdvbtee/decode -I../../libdvbtee/decode/table -I../../libdvbtee/decode/descriptor
 
 bin_PROGRAMS = walk-hls
 walk_hls_SOURCES = main.cpp hlsinput.cpp

--- a/libdvbtee/Makefile.am
+++ b/libdvbtee/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I./decode -I./decode/table -I/usr/include/libhdhomerun -I/usr/lib/libhdhomerun -I/opt/local/include -pthread -D__STDC_FORMAT_MACROS
+AM_CXXFLAGS = -I./decode -I./decode/table -I./decode/descriptor -I/usr/include/libhdhomerun -I/usr/lib/libhdhomerun -I/opt/local/include -pthread -D__STDC_FORMAT_MACROS
 
 lib_LTLIBRARIES = libdvbtee.la
 

--- a/libdvbtee/decode.h
+++ b/libdvbtee/decode.h
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <time.h>
 
-#include "decode/table/table.h"
+#include "table.h"
 
 #include "dvbpsi/pat.h"
 #include "dvbpsi/pmt.h"

--- a/libdvbtee/decode/Makefile.am
+++ b/libdvbtee/decode/Makefile.am
@@ -95,7 +95,7 @@ endif DRA1
 
 EXTRA_DIST = decoder.h \
              table/table.h \
-             descriptor/descriptor.h
+             descriptor/descript.h
 
 DVBTEE_DECODE_LIBRARY_VERSION=0:0:0
 
@@ -104,6 +104,6 @@ libdvbtee_decode_la_LDFLAGS = -version-info $(DVBTEE_DECODE_LIBRARY_VERSION)
 library_includedir=$(includedir)/dvbtee
 library_include_HEADERS = decoder.h \
              table/table.h \
-             descriptor/descriptor.h
+             descriptor/descript.h
 
 libdvbtee_decode_la_LIBADD = -L../value -lvalueobj

--- a/libdvbtee/decode/descriptor/desc_0a.h
+++ b/libdvbtee/decode/descriptor/desc_0a.h
@@ -24,7 +24,7 @@
 
 #include <map>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_48.h
+++ b/libdvbtee/decode/descriptor/desc_48.h
@@ -24,7 +24,7 @@
 
 #include <map>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_4d.h
+++ b/libdvbtee/decode/descriptor/desc_4d.h
@@ -24,7 +24,7 @@
 
 #include <map>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_62.h
+++ b/libdvbtee/decode/descriptor/desc_62.h
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_81.h
+++ b/libdvbtee/decode/descriptor/desc_81.h
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_83.h
+++ b/libdvbtee/decode/descriptor/desc_83.h
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_86.h
+++ b/libdvbtee/decode/descriptor/desc_86.h
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_a0.h
+++ b/libdvbtee/decode/descriptor/desc_a0.h
@@ -24,7 +24,7 @@
 
 #include <map>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/desc_a1.h
+++ b/libdvbtee/decode/descriptor/desc_a1.h
@@ -24,7 +24,7 @@
 
 #include <map>
 
-#include "descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/descriptor/descript.h
+++ b/libdvbtee/decode/descriptor/descript.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (C) 2011-2016 Michael Ira Krufky
+ * Copyright (C) 2011-2017 Michael Ira Krufky
  *
  * Author: Michael Ira Krufky <mkrufky@linuxtv.org>
  *

--- a/libdvbtee/decode/descriptor/descriptor.cpp
+++ b/libdvbtee/decode/descriptor/descriptor.cpp
@@ -19,7 +19,7 @@
  *
  *****************************************************************************/
 
-#include "descriptor.h"
+#include "descript.h"
 
 #define CLASS_MODULE "DESCRIPTOR"
 

--- a/libdvbtee/decode/descriptor/descriptor.h
+++ b/libdvbtee/decode/descriptor/descriptor.h
@@ -27,7 +27,7 @@
 #include <pthread.h>
 #include <vector>
 
-#include "decode/decoder.h"
+#include "decoder.h"
 #include "dvbpsi/descriptor.h"
 
 #include "log.h"

--- a/libdvbtee/decode/descriptor/descriptor.pri
+++ b/libdvbtee/decode/descriptor/descriptor.pri
@@ -34,4 +34,4 @@ HEADERS += \
     $$PWD/desc_86.h \
     $$PWD/desc_a0.h \
     $$PWD/desc_a1.h \
-    $$PWD/descriptor.h
+    $$PWD/descript.h

--- a/libdvbtee/decode/table/table.h
+++ b/libdvbtee/decode/table/table.h
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "decoder.h"
-#include "decode/descriptor/descriptor.h"
+#include "descript.h"
 
 namespace dvbtee {
 

--- a/libdvbtee/decode/table/table.h
+++ b/libdvbtee/decode/table/table.h
@@ -24,7 +24,7 @@
 
 #include <string>
 
-#include "decode/decoder.h"
+#include "decoder.h"
 #include "decode/descriptor/descriptor.h"
 
 namespace dvbtee {

--- a/libdvbtee/listen.cpp
+++ b/libdvbtee/listen.cpp
@@ -26,6 +26,10 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include "dvbtee_config.h"
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
 #include "listen.h"
 #include "log.h"
 #include "dvbtee_config.h"

--- a/libdvbtee/listen.h
+++ b/libdvbtee/listen.h
@@ -22,10 +22,6 @@
 #ifndef __LISTEN_H__
 #define __LISTEN_H__
 
-#include "dvbtee_config.h"
-#ifdef HAVE_ARPA_INET_H
-#include <arpa/inet.h>
-#endif
 #include <pthread.h>
 #include <stdint.h>
 #include <string.h>

--- a/libdvbtee/output.cpp
+++ b/libdvbtee/output.cpp
@@ -145,7 +145,7 @@ const std::string http_response(enum output_mimetype mimetype)
 }
 
 ssize_t socket_send(int sockfd, const void *buf, size_t len, int flags,
-		    const struct sockaddr *dest_addr, socklen_t addrlen)
+		    const struct sockaddr *dest_addr, int addrlen)
 {
 	if (sockfd < 0)
 		return sockfd;
@@ -174,10 +174,10 @@ ssize_t socket_send(int sockfd, const void *buf, size_t len, int flags,
 	return (ret > 0) ?
 #if 0
 		((dest_addr) && (addrlen)) ?
-			sendto(sockfd, buf, len, flags, dest_addr, addrlen) :
+			sendto(sockfd, buf, len, flags, dest_addr, (socklen_t) addrlen) :
 			send(sockfd, buf, len, flags) :
 #else
-		sendto(sockfd, (const char *)buf, len, flags|MSG_NOSIGNAL, dest_addr, addrlen) :
+		sendto(sockfd, (const char *)buf, len, flags|MSG_NOSIGNAL, dest_addr, (socklen_t) addrlen) :
 #endif
 		ret;
 }

--- a/libdvbtee/output.h
+++ b/libdvbtee/output.h
@@ -39,7 +39,7 @@
 typedef std::map<uint16_t, uint16_t> map_pidtype;
 #endif
 ssize_t socket_send(int sockfd, const void *buf, size_t len, int flags,
-		    const struct sockaddr *dest_addr = NULL, socklen_t addrlen = 0);
+		    const struct sockaddr *dest_addr = NULL, int addrlen = 0);
 
 int stream_http_chunk(int socket, const uint8_t *buf, size_t length, const bool send_zero_length = false);
 

--- a/libdvbtee/parse.h
+++ b/libdvbtee/parse.h
@@ -33,7 +33,7 @@
 /* update version number by updating the LIBDVBTEE_VERSION_FOO fields below */
 #define LIBDVBTEE_VERSION_A 0
 #define LIBDVBTEE_VERSION_B 4
-#define LIBDVBTEE_VERSION_C 8
+#define LIBDVBTEE_VERSION_C 9
 
 #define QUOTE(str) #str
 #define EXPAND_AND_QUOTE(str) QUOTE(str)

--- a/libdvbtee/value/Makefile.am
+++ b/libdvbtee/value/Makefile.am
@@ -8,5 +8,5 @@ VALOBJ_LIBRARY_VERSION=1:0:0
 
 libvalueobj_la_LDFLAGS = -version-info $(VALOBJ_LIBRARY_VERSION)
 
-library_includedir=$(includedir)/valueobj
+library_includedir=$(includedir)/value
 library_include_HEADERS = value.h object.h array.h

--- a/libdvbtee_server/Makefile.am
+++ b/libdvbtee_server/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee/decode -I../libdvbtee/decode/table
+AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee/decode -I../libdvbtee/decode/table -I../libdvbtee/decode/descriptor
 
 lib_LTLIBRARIES = libdvbtee_server.la
 

--- a/libdvbtee_server/Makefile.am
+++ b/libdvbtee_server/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee/decode/table
+AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee/decode -I../libdvbtee/decode/table
 
 lib_LTLIBRARIES = libdvbtee_server.la
 

--- a/libdvbtee_server/Makefile.am
+++ b/libdvbtee_server/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I../libdvbtee
+AM_CXXFLAGS = -I../libdvbtee -I../libdvbtee/decode/table
 
 lib_LTLIBRARIES = libdvbtee_server.la
 

--- a/tunerprovider/Makefile.am
+++ b/tunerprovider/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../libdvbtee -I/usr/include/libhdhomerun
-AM_CXXFLAGS += -I../libdvbtee/decode/table
+AM_CXXFLAGS += -I../libdvbtee/decode -I../libdvbtee/decode/table
 
 lib_LTLIBRARIES = libdvbtee_tunerprovider.la
 

--- a/tunerprovider/Makefile.am
+++ b/tunerprovider/Makefile.am
@@ -1,4 +1,5 @@
 AM_CXXFLAGS = -I../libdvbtee -I/usr/include/libhdhomerun
+AM_CXXFLAGS += -I../libdvbtee/decode/table
 
 lib_LTLIBRARIES = libdvbtee_tunerprovider.la
 

--- a/tunerprovider/Makefile.am
+++ b/tunerprovider/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I../libdvbtee -I/usr/include/libhdhomerun
-AM_CXXFLAGS += -I../libdvbtee/decode -I../libdvbtee/decode/table
+AM_CXXFLAGS += -I../libdvbtee/decode -I../libdvbtee/decode/table -I../libdvbtee/decode/descriptor
 
 lib_LTLIBRARIES = libdvbtee_tunerprovider.la
 

--- a/version.m4
+++ b/version.m4
@@ -1,1 +1,1 @@
-m4_define([DVBTEE_VERSION],[0.4.8])
+m4_define([DVBTEE_VERSION],[0.4.9])


### PR DESCRIPTION
* fix fatal error: dvbtee_config.h: No such file or directory
* fix fatal error: decode/descriptor/descriptor.h: No such file or directory
* fix fatal error: value/value.h: No such file or directory
* fix fatal error: decode/decoder.h: No such file or directory
* fix fatal error: decode/table/table.h: No such file or directory