### PR TITLE
serve: fix build breakage under win32 due to mkdir

### DIFF
--- a/libdvbtee_server/serve.cpp
+++ b/libdvbtee_server/serve.cpp
@@ -1188,7 +1188,7 @@ bool serve_client::cmd_tuner_scan_channels_save()
 		  "waiting for channel scan to complete and " : "",
 		  filepath);
 
-#ifdef HAVE_MKDIR
+#if !defined(_WIN32) && defined(HAVE_MKDIR)
 	if (mkdir(dir, 0777) < 0) {
 #else
 	char cmd_buf[32] = { 0 };


### PR DESCRIPTION
closes #36

```
serve.cpp: In member function 'bool
serve_client::cmd_tuner_scan_channels_save()':
serve.cpp:1192:21: error: too many arguments to function 'int
mkdir(const char*)'
if (mkdir(dir, 0777) < 0) {
^
In file included from
/Users/packrd/dev/ruby/ffmpeg-windows-build-helpers/sandbox/cross_compilers/mingw-w64-i686/include/fcntl.h:8:0,
from serve.cpp:27:
/Users/packrd/dev/ruby/ffmpeg-windows-build-helpers/sandbox/cross_compilers/mingw-w64-i686/include/io.h:280:15:
note: declared here
int __cdecl mkdir (const char *) __MINGW_ATTRIB_DEPRECATED_MSVC2005;
^
make[2]: *** [serve.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```