### PR TITLE
desc_4e: add support for extended event descriptor 0x4e

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,12 @@ AM_COND_IF([DVBPSIBUILD], [
   AM_CONDITIONAL([DR4D], [test x$DR4D = xtrue])
 ])
 AM_COND_IF([DVBPSIBUILD], [
+  AM_CONDITIONAL([DR4E], [true])
+], [
+  AC_CHECK_FUNC([dvbpsi_DecodeExtendedEventDr],[DR4E=true],[DR4E=false])
+  AM_CONDITIONAL([DR4E], [test x$DR4E = xtrue])
+])
+AM_COND_IF([DVBPSIBUILD], [
   AM_CONDITIONAL([DR62], [true])
 ], [
   AC_CHECK_FUNC([dvbpsi_DecodeFrequencyListDr],[DR62=true],[DR62=false])

--- a/libdvbtee/decode/Makefile.am
+++ b/libdvbtee/decode/Makefile.am
@@ -69,6 +69,9 @@ endif DR48
 if DR4D
 libdvbtee_decode_la_SOURCES += descriptor/desc_4d.cpp descriptor/desc_4d.h
 endif DR4D
+if DR4E
+libdvbtee_decode_la_SOURCES += descriptor/desc_4e.cpp descriptor/desc_4e.h
+endif DR4E
 
 # requires libdvbpsi v1.x.x
 if DR62

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -1,0 +1,78 @@
+/*****************************************************************************
+ * Copyright (C) 2011-2016 Michael Ira Krufky
+ *
+ * Author: Michael Ira Krufky <mkrufky@linuxtv.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#include <stdlib.h>
+
+#include "desc_4e.h"
+
+#include "dvbpsi/dr_4e.h" /* extended event descriptor */
+
+#include "functions.h"
+
+#define CLASS_MODULE "[extended event]"
+
+#define dPrintf(fmt, arg...) __dPrintf(DBG_DESC, fmt, ##arg)
+
+using namespace dvbtee::decode;
+using namespace valueobj;
+
+static std::string DESC_NAME = "DR[4E]";
+
+#define DESC_TAG 0x4E
+
+desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
+ : Descriptor(parent, DESC_NAME, p_descriptor)
+{
+	if (!desc_check_tag(getTag(), DESC_TAG)) return;
+
+	dvbpsi_extended_event_dr_t* dr = dvbpsi_DecodeExtendedEventDr(p_descriptor);
+	if (desc_dr_failed(dr)) return;
+
+	unsigned char text[256];
+	unsigned char lang[4] = { 0 };
+
+	for (unsigned int i = 0; i < 3; i++) lang[i] = dr->i_iso_639_code[i];
+	get_descriptor_text(dr->i_text, dr->i_text_length, text);
+
+	set("descriptor_number", dr->i_descriptor_number);
+	set("last_descriptor_number", dr->i_last_descriptor_number);
+	set("lang", std::string((const char*)lang));
+
+	/* FIXME: we should escape these strings on output rather than on store */
+	if (strchr((char*)text, '"')) {
+		char* escaped = escape_quotes((char*)text);
+		set("text", std::string(escaped));
+		free(escaped);
+	} else {
+		set("text", std::string((char*)text));
+	}
+
+	dPrintf("%s", toJson().c_str());
+
+	setValid(true);
+}
+
+desc_4e::~desc_4e()
+{
+	//
+}
+
+REGISTER_DESCRIPTOR_FACTORY(DESC_TAG, desc_4e)

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -36,7 +36,7 @@ using namespace valueobj;
 
 static std::string DESC_NAME = "DR[4E]";
 
-#define DESC_TAG 0x4E
+#define DESC_TAG 0x4e
 
 desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
  : Descriptor(parent, DESC_NAME, p_descriptor)

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (C) 2011-2016 Michael Ira Krufky
+ * Copyright (C) 2011-2017 Michael Ira Krufky
  *
  * Author: Michael Ira Krufky <mkrufky@linuxtv.org>
  *

--- a/libdvbtee/decode/descriptor/desc_4e.h
+++ b/libdvbtee/decode/descriptor/desc_4e.h
@@ -1,0 +1,46 @@
+/*****************************************************************************
+ * Copyright (C) 2011-2016 Michael Ira Krufky
+ *
+ * Author: Michael Ira Krufky <mkrufky@linuxtv.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef __4E_H__
+#define __4E_H__
+
+#include <map>
+
+#include "descript.h"
+
+namespace dvbtee {
+
+namespace decode {
+
+/* extended event descriptor */
+
+class desc_4e: public Descriptor {
+DESCRIPTOR_DECODER_TPL
+public:
+	desc_4e(Decoder *, dvbpsi_descriptor_t*);
+	virtual ~desc_4e();
+};
+
+}
+
+}
+
+#endif /* __4E_H__ */

--- a/libdvbtee/decode/descriptor/desc_4e.h
+++ b/libdvbtee/decode/descriptor/desc_4e.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (C) 2011-2016 Michael Ira Krufky
+ * Copyright (C) 2011-2017 Michael Ira Krufky
  *
  * Author: Michael Ira Krufky <mkrufky@linuxtv.org>
  *

--- a/libdvbtee/decode/descriptor/descriptor.cpp
+++ b/libdvbtee/decode/descriptor/descriptor.cpp
@@ -32,6 +32,7 @@ using namespace valueobj;
 #include "desc_0a.h"
 #include "desc_48.h"
 #include "desc_4d.h"
+#include "desc_4e.h"
 #include "desc_62.h"
 #include "desc_81.h"
 #include "desc_83.h"
@@ -44,6 +45,7 @@ static void load()
 	desc_0a::__load();
 	desc_48::__load();
 	desc_4d::__load();
+	desc_4e::__load();
 	desc_62::__load();
 	desc_81::__load();
 	desc_83::__load();

--- a/libdvbtee/decode/descriptor/descriptor.pri
+++ b/libdvbtee/decode/descriptor/descriptor.pri
@@ -3,7 +3,8 @@ INCLUDEPATH += $$PWD
 DESCRIPTOR_REQ_DVBPSI_V0_2_SOURCES = \
     $$PWD/desc_0a.cpp \
     $$PWD/desc_48.cpp \
-    $$PWD/desc_4d.cpp
+    $$PWD/desc_4d.cpp \
+    $$PWD/desc_4e.cpp
 
 DESCRIPTOR_REQ_DVBPSI_V1_SOURCES = \
     $$DESCRIPTOR_REQ_DVBPSI_V0_2_SOURCES \
@@ -28,6 +29,7 @@ HEADERS += \
     $$PWD/desc_0a.h \
     $$PWD/desc_48.h \
     $$PWD/desc_4d.h \
+    $$PWD/desc_4e.h \
     $$PWD/desc_62.h \
     $$PWD/desc_81.h \
     $$PWD/desc_83.h \

--- a/libdvbtee/desc.cpp
+++ b/libdvbtee/desc.cpp
@@ -147,7 +147,7 @@ bool desc::extended_event(dvbpsi_descriptor_t* p_descriptor)
 	if (p_descriptor->i_tag != DT_ExtendedEvent)
 		return false;
 
-	dvbpsi_extended_event_dr_t* dr = dvbpsi_ExtendedShortEventDr(p_descriptor);
+	dvbpsi_extended_event_dr_t* dr = dvbpsi_DecodeExtendedEventDr(p_descriptor);
 	if (desc_dr_failed(dr)) return false;
 
 	_4e->descriptor_number = dr->i_descriptor_number;

--- a/libdvbtee/desc.cpp
+++ b/libdvbtee/desc.cpp
@@ -39,6 +39,7 @@
 #include "dvbpsi/dr_0a.h" /* ISO639 language descriptor */
 #include "dvbpsi/dr_48.h" /* service descriptor */
 #include "dvbpsi/dr_4d.h" /* short event descriptor */
+#include "dvbpsi/dr_4e.h" /* extended event descriptor */
 #if DVBPSI_SUPPORTS_DR_81_86_A0_A1
 #include "dvbpsi/dr_62.h" /* frequency list descriptor */
 #include "dvbpsi/dr_81.h" /* AC-3 Audio descriptor */
@@ -55,6 +56,7 @@
 #define DT_ISO639Language             0x0a
 #define DT_Service                    0x48
 #define DT_ShortEvent                 0x4d
+#define DT_ExtendedEvent              0x4e
 #define DT_Teletext                   0x56
 #define DT_FrequencyList              0x62
 #define DT_Ac3Audio                   0x81
@@ -136,6 +138,24 @@ bool desc::short_event(dvbpsi_descriptor_t* p_descriptor)
 	get_descriptor_text(dr->i_text, dr->i_text_length, _4d.text);
 
 	dPrintf("%s, %s, %s", _4d.lang, _4d.name, _4d.text);
+
+	return true;
+}
+
+bool desc::extended_event(dvbpsi_descriptor_t* p_descriptor)
+{
+	if (p_descriptor->i_tag != DT_ExtendedEvent)
+		return false;
+
+	dvbpsi_extended_event_dr_t* dr = dvbpsi_ExtendedShortEventDr(p_descriptor);
+	if (desc_dr_failed(dr)) return false;
+
+	_4e->descriptor_number = dr->i_descriptor_number;
+	_4e->last_descriptor_number = dr->i_last_descriptor_number;
+	memcpy(_4e.lang, dr->i_iso_639_code, 3);
+	get_descriptor_text(dr->i_text, dr->i_text_length, _4e.text);
+
+	dPrintf("%s, %s", _4e.lang, _4e.text);
 
 	return true;
 }

--- a/libdvbtee/desc.cpp
+++ b/libdvbtee/desc.cpp
@@ -150,8 +150,8 @@ bool desc::extended_event(dvbpsi_descriptor_t* p_descriptor)
 	dvbpsi_extended_event_dr_t* dr = dvbpsi_DecodeExtendedEventDr(p_descriptor);
 	if (desc_dr_failed(dr)) return false;
 
-	_4e->descriptor_number = dr->i_descriptor_number;
-	_4e->last_descriptor_number = dr->i_last_descriptor_number;
+	_4e.descriptor_number = dr->i_descriptor_number;
+	_4e.last_descriptor_number = dr->i_last_descriptor_number;
 	memcpy(_4e.lang, dr->i_iso_639_code, 3);
 	get_descriptor_text(dr->i_text, dr->i_text_length, _4e.text);
 

--- a/libdvbtee/desc.cpp
+++ b/libdvbtee/desc.cpp
@@ -438,6 +438,9 @@ void desc::decode(dvbpsi_descriptor_t* p_descriptor)
 		case DT_ShortEvent:
 			short_event(p_descriptor);
 			break;
+		case DT_ExtendedEvent:
+			extended_event(p_descriptor);
+			break;
 		case DT_FrequencyList:
 			freq_list(p_descriptor);
 			break;

--- a/libdvbtee/desc.h
+++ b/libdvbtee/desc.h
@@ -43,6 +43,14 @@ typedef struct
 
 typedef struct
 {
+	uint8_t       descriptor_number;
+	uint8_t       last_descriptor_number;
+	unsigned char lang[4];
+	unsigned char text[256];
+} dr4e_t;
+
+typedef struct
+{
 	uint8_t       stream_type;
 	uint16_t      elementary_pid;
 	unsigned char iso_639_code[3];
@@ -71,6 +79,7 @@ public:
 	map_dr0a _0a;
 
 	dr4d_t _4d;
+	dr4e_t _4e;
 
 	map_dra1 _a1;
 

--- a/libdvbtee/desc.h
+++ b/libdvbtee/desc.h
@@ -89,7 +89,7 @@ private:
 	bool iso639language(dvbpsi_descriptor_t*);
 	bool service(dvbpsi_descriptor_t*);
 	bool short_event(dvbpsi_descriptor_t*);
-	bool extended_event(dvbpsi_descriptor_t*)
+	bool extended_event(dvbpsi_descriptor_t*);
 	bool freq_list(dvbpsi_descriptor_t*);
 	bool ac3_audio(dvbpsi_descriptor_t*);
 	bool _lcn(dvbpsi_descriptor_t*);

--- a/libdvbtee/desc.h
+++ b/libdvbtee/desc.h
@@ -89,6 +89,7 @@ private:
 	bool iso639language(dvbpsi_descriptor_t*);
 	bool service(dvbpsi_descriptor_t*);
 	bool short_event(dvbpsi_descriptor_t*);
+	bool extended_event(dvbpsi_descriptor_t*)
 	bool freq_list(dvbpsi_descriptor_t*);
 	bool ac3_audio(dvbpsi_descriptor_t*);
 	bool _lcn(dvbpsi_descriptor_t*);


### PR DESCRIPTION
TO DO: the data from this descriptor still hasn't been integrated into `decode` or any c++ API, but this does enable `node-dvbtee` and any other PSIP dumps.