### PR TITLE
linuxtv_tuner: initial support for memory-mapped IO

### DIFF
--- a/libdvbtee/Makefile.am
+++ b/libdvbtee/Makefile.am
@@ -8,6 +8,7 @@ libdvbtee_la_SOURCES = \
     curlhttpget.cpp \
     decode.cpp \
     demux.cpp \
+    dvb-vb2.cpp \
     feed.cpp \
     functions.cpp \
     hdhr_tuner.cpp \
@@ -27,6 +28,7 @@ EXTRA_DIST = \
     curlhttpget.h \
     decode.h \
     demux.h \
+    dvb-vb2.h \
     feed.h \
     functions.h \
     hdhr_tuner.h \
@@ -52,6 +54,7 @@ library_include_HEADERS = \
     curlhttpget.h \
     decode.h \
     demux.h \
+    dvb-vb2.h \
     feed.h \
     functions.h \
     hdhr_tuner.h \

--- a/libdvbtee/dvb-vb2.cpp
+++ b/libdvbtee/dvb-vb2.cpp
@@ -173,7 +173,7 @@ int stream_init(struct stream_ctx *sc,
 
 	ret = xioctl(in_fd, DMX_REQBUFS, &req);
 	if (ret) {
-		dvb_perror("DMX_REQBUFS failed");
+		//dvb_perror("DMX_REQBUFS failed");
 		return ret;
 	}
 

--- a/libdvbtee/dvb-vb2.cpp
+++ b/libdvbtee/dvb-vb2.cpp
@@ -55,9 +55,6 @@
 #include <libdvbv5/dvb-dev.h>
 #endif
 
-/**These 2 params are for DVR*/
-#define STREAM_BUF_CNT (10)
-#define STREAM_BUF_SIZ (188*1024)
 /*Sleep time for retry, in case ioctl fails*/
 #define SLEEP_US	1000
 

--- a/libdvbtee/dvb-vb2.cpp
+++ b/libdvbtee/dvb-vb2.cpp
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c)      2018 - Michael Ira Krufky <mkrufky@linuxtv.org>
+ * Copyright (c) 2017-2018 - Mauro Carvalho Chehab
+ * Copyright (c) 2017-2018 - Junghak Sung <jh1009.sung@samsung.com>
+ * Copyright (c) 2017-2018 - Satendra Singh Thakur <satendra.t@samsung.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation version 2.1 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * Or, point your browser to http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
+/******************************************************************************
+ * Implements videobuf2 streaming APIs for DVB
+ *****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <sys/time.h>
+
+#include <config.h>
+
+#include <sys/mman.h>
+
+#if 1
+#include "dvb-vb2.h"
+#include "log.h"
+#define CLASS_MODULE "dvbvb2"
+
+#define dPrintf(fmt, arg...) __dPrintf(DBG_TUNE, fmt, ##arg)
+
+#define dvb_perror perror
+#define dvb_loginfo dPrintf
+#define dvb_logerr dPrintf
+#else
+#include <libdvbv5/dvb-log.h>
+#include <libdvbv5/dvb-vb2.h>
+#include <libdvbv5/dvb-dev.h>
+#endif
+
+/**These 2 params are for DVR*/
+#define STREAM_BUF_CNT (10)
+#define STREAM_BUF_SIZ (188*1024)
+/*Sleep time for retry, in case ioctl fails*/
+#define SLEEP_US	1000
+
+#define memzero(x) memset(&(x), 0, sizeof(x))
+
+static inline int xioctl(int fd, unsigned long int cmd, void *arg)
+{
+	int ret;
+	struct timespec stime, etime;
+	long long etimell = 0;
+	clock_gettime(CLOCK_MONOTONIC, &stime);
+	long long stimell = (long long) (stime.tv_sec + 1 /*1 sec wait*/)
+					* 1000000000 + stime.tv_nsec;
+	do {
+		ret = ioctl(fd, cmd, arg);
+		if (ret < 0 && (errno == EINTR || errno == EAGAIN)) {
+			clock_gettime(CLOCK_MONOTONIC, &etime);
+			etimell = (long long) etime.tv_sec * 1000000000 +
+					etime.tv_nsec;
+			if (etimell > stimell)
+				break;
+			/* wait for some time to prevent cpu hogging */
+			usleep(SLEEP_US);
+			continue;
+		}
+		else
+			break;
+	} while (1);
+
+	return ret;
+}
+
+int stream_qbuf(struct stream_ctx *sc, int idx)
+{
+	struct dmx_buffer buf;
+	int ret;
+
+	memzero(buf);
+	buf.index = idx;
+
+	ret = xioctl(sc->in_fd, DMX_QBUF, &buf);
+	if (ret < 0) {
+		dvb_perror("DMX_QBUF failed");
+		return ret;
+	}
+
+	return ret;
+}
+
+int stream_dqbuf(struct stream_ctx *sc,
+		 struct dmx_buffer *buf)
+{
+	static int64_t count = -1;
+	int ret, flags;
+
+	ret = xioctl(sc->in_fd, DMX_DQBUF, buf);
+	if (ret < 0) {
+		dvb_perror("DMX_DQBUF failed");
+		return ret;
+	}
+
+	if (count >= 0 && (buf->count != (uint32_t)(count + 1)))
+		dvb_logerr("Frame lost. Expected %d, received %d", (uint32_t) count + 1, buf->count);
+
+	count = buf->count;
+
+	if (!buf->flags)
+		return ret;
+
+	flags = buf->flags;
+
+	if (flags & DMX_BUFFER_FLAG_HAD_CRC32_DISCARD) {
+		flags &= ~DMX_BUFFER_FLAG_HAD_CRC32_DISCARD;
+		dvb_logerr("Kernel discarded packets with invalid checksums");
+	}
+	if (flags & DMX_BUFFER_FLAG_TEI) {
+		flags &= ~DMX_BUFFER_FLAG_TEI;
+		dvb_logerr("Transport Error indicator");
+	}
+	if (flags & DMX_BUFFER_PKT_COUNTER_MISMATCH) {
+		flags &= ~DMX_BUFFER_PKT_COUNTER_MISMATCH;
+		dvb_logerr("Packet counter mismatch");
+	}
+	if (flags & DMX_BUFFER_FLAG_DISCONTINUITY_DETECTED) {
+		flags &= ~DMX_BUFFER_FLAG_DISCONTINUITY_DETECTED;
+		dvb_logerr("Kernel detected packet discontinuity");
+	}
+	if (flags & DMX_BUFFER_FLAG_DISCONTINUITY_INDICATOR) {
+		flags &= ~DMX_BUFFER_FLAG_DISCONTINUITY_INDICATOR;
+		dvb_logerr("Kernel received a discontinuity indicator");
+	}
+	if (flags)
+		dvb_logerr("Unknown error: 0x%04x", flags);
+
+	return ret;
+}
+
+int stream_expbuf(struct stream_ctx *sc, int idx)
+{
+	int ret;
+	struct dmx_exportbuffer exp;
+	memzero(exp);
+	exp.index = idx;
+	ret = ioctl(sc->in_fd, DMX_EXPBUF, &exp);
+	if (ret) {
+		dvb_perror("DMX_EXPBUF failed");
+		return ret;
+	}
+	sc->exp_fd[idx] = exp.fd;
+	dvb_loginfo("Export buffer %d (fd=%d)", idx, sc->exp_fd[idx]);
+	return ret;
+}
+
+int stream_init(struct stream_ctx *sc,
+		int in_fd, int buf_cnt, int buf_size)
+{
+	struct dmx_requestbuffers req;
+	struct dmx_buffer buf;
+	int ret;
+	int i;
+
+	memset(sc, 0, sizeof(struct stream_ctx));
+	sc->in_fd = in_fd;
+	sc->buf_size = buf_size;
+	sc->buf_cnt = buf_cnt;
+
+	memzero(req);
+	req.count = sc->buf_cnt;
+	req.size = sc->buf_size;
+
+	ret = xioctl(in_fd, DMX_REQBUFS, &req);
+	if (ret) {
+		dvb_perror("DMX_REQBUFS failed");
+		return ret;
+	}
+
+	if (sc->buf_cnt != req.count) {
+		dvb_logerr("buf_cnt %d -> %d changed !!!",
+			   sc->buf_cnt, req.count);
+		sc->buf_cnt = req.count;
+	}
+
+	for (i = 0; i < sc->buf_cnt; i++) {
+		memzero(buf);
+		buf.index = i;
+
+		ret = xioctl(in_fd, DMX_QUERYBUF, &buf);
+		if (ret) {
+			dvb_perror("DMX_QUERYBUF failed");
+			return ret;
+		}
+
+		sc->buf[i] = (unsigned char*)
+		            mmap(NULL, buf.length,
+					PROT_READ | PROT_WRITE, MAP_SHARED,
+					in_fd, buf.offset);
+
+		if (sc->buf[i] == MAP_FAILED) {
+			dvb_perror("Failed to MMAP buffer");
+			return -1;
+		}
+		/**enqueue the buffers*/
+		ret = stream_qbuf(sc, i);
+		if (ret) {
+			dvb_perror("stream_qbuf failed");
+			return ret;
+		}
+
+		sc->buf_flag[i] = 1;
+	}
+
+	return 0;
+}
+
+void stream_deinit(struct stream_ctx *sc)
+{
+	struct dmx_buffer buf;
+	int ret;
+	int i;
+
+	for (i = 0; i < sc->buf_cnt; i++) {
+		memzero(buf);
+		buf.index = i;
+
+		if (sc->buf_flag[i]) {
+			ret = stream_dqbuf(sc, &buf);
+			if (ret) {
+				dvb_perror("stream_dqbuf failed");
+			}
+		}
+		ret = munmap(sc->buf[i], sc->buf_size);
+		if (ret) {
+			dvb_perror("munmap failed");
+		}
+
+	}
+
+	return;
+}
+
+void stream_to_file(int in_fd, int out_fd,
+		    int timeout, int dbg_level, int *exit_flag)
+{
+	struct stream_ctx sc;
+	int ret, n;
+	long long int rc = 0LL;
+
+	ret = stream_init(&sc, in_fd, STREAM_BUF_CNT,
+			  STREAM_BUF_SIZ);
+	if (ret < 0) {
+		dvb_perror("Failed to setup buffers");
+		sc.error = 1;
+		return;
+	}
+	dvb_loginfo("started memory-mapped streaming");
+
+	while (!*exit_flag  && !sc.error) {
+		n = 0;
+		/* find empty buffer */
+		while (n < sc.buf_cnt && sc.buf_flag[n])
+			n++;
+
+		if (n >= sc.buf_cnt) {
+			struct dmx_buffer b;
+
+			/* dequeue the buffer */
+			memzero(b);
+			ret = stream_dqbuf(&sc, &b);
+			if (ret < 0) {
+				sc.error = 1;
+				break;
+			}
+
+			sc.buf_flag[b.index] = 0;
+			if (out_fd >= 0) {
+				ret = write(out_fd, sc.buf[b.index],
+					    b.bytesused);
+				if (ret < 0) {
+					dvb_perror("Write failed");
+					break;
+				}
+			}
+			rc += b.bytesused;
+		} else {
+			/* enqueue the buffer */
+			ret = stream_qbuf(&sc, n);
+			if (ret < 0)
+				sc.error = 1;
+			else
+				sc.buf_flag[n] = 1;
+		}
+	}
+	if (dbg_level < 2 && timeout) {
+		dvb_loginfo("copied %lld bytes (%lld Kbytes/sec)",
+			    rc, rc / (1024 * timeout));
+	}
+	stream_deinit(&sc);
+}

--- a/libdvbtee/dvb-vb2.cpp
+++ b/libdvbtee/dvb-vb2.cpp
@@ -23,6 +23,8 @@
  * Implements videobuf2 streaming APIs for DVB
  *****************************************************************************/
 
+#include "dvbtee_config.h"
+#ifdef USE_LINUXTV
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
@@ -238,3 +240,4 @@ void stream_deinit(struct stream_ctx *sc)
 
 	return;
 }
+#endif

--- a/libdvbtee/dvb-vb2.h
+++ b/libdvbtee/dvb-vb2.h
@@ -23,15 +23,6 @@
 
 #include <stdint.h>
 #include <linux/dvb/dmx.h>
-#if 1
-typedef void (*dvb_logfunc)(int level, const char *fmt, ...) __attribute__ (( format( printf, 2, 3 )));
-#define MAX_DELIVERY_SYSTEMS      20
-#define MAX_STREAM_BUF_CNT       10
-#define STREAM_BUF_CNT (10)
-#define DVB_MAX_PAYLOAD_PACKET_SIZE 4096
-#define STREAM_BUF_SIZ (DVB_MAX_PAYLOAD_PACKET_SIZE)
-#include <linux/dvb/frontend.h>
-#endif
 
 /**
  * @file dvb-vb2.h

--- a/libdvbtee/dvb-vb2.h
+++ b/libdvbtee/dvb-vb2.h
@@ -97,18 +97,6 @@ int stream_qbuf(struct stream_ctx *sc, int idx);
 int stream_dqbuf(struct stream_ctx *sc,
 		 struct dmx_buffer *buf);
 /**
- * sream_expbuf - Exports a buffer specified by buf argument
- *
- * @param sc		Context for streaming management
- *			Pointer to &struct stream_ctx
- * @param idx		Index of the buffer
- *
- * @return At return, it returns a negative value if error or
- * zero on success.
- */
-int stream_expbuf(struct stream_ctx *sc,
-		  int idx);
-/**
  * stream_init - Requests number of buffers from memory
  * Gets pointer to the buffers from driver, mmaps those buffers
  * and stores them in an array
@@ -133,21 +121,6 @@ int stream_init(struct stream_ctx *sc,
  * @param sc		Pointer to &struct stream_ctx
  */
 void stream_deinit(struct stream_ctx *sc);
-/**
- * stream_to_file - Implements enqueue and dequeue logic
- * First enqueues all the available buffers then dequeues
- * one buffer, again enqueues it and so on.
- *
- * @param in_fd		File descriptor of the streaming device
- * @param out_fd	File descriptor of output file
- * @param timeout	Timeout in seconds
- * @param dbg_level	Debug flag
- * @param exit_flag	Flag to exit
- *
- * @return void
- */
-void stream_to_file(struct dvb_v5_fe_parms *parms, int in_fd, int out_fd,
-		    int timeout, int dbg_level, int *exit_flag);
 
 #ifdef __cplusplus
 }

--- a/libdvbtee/dvb-vb2.h
+++ b/libdvbtee/dvb-vb2.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c)      2018 - Michael Ira Krufky <mkrufky@linuxtv.org>
+ * Copyright (c) 2017-2018 - Mauro Carvalho Chehab
+ * Copyright (c) 2017-2018 - Junghak Sung <jh1009.sung@samsung.com>
+ * Copyright (c) 2017-2018 - Satendra Singh Thakur <satendra.t@samsung.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation version 2.1 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * Or, point your browser to http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+#ifndef _LIBVB2_H
+#define _LIBVB2_H
+
+#include <stdint.h>
+#include <linux/dvb/dmx.h>
+#if 1
+typedef void (*dvb_logfunc)(int level, const char *fmt, ...) __attribute__ (( format( printf, 2, 3 )));
+#define MAX_DELIVERY_SYSTEMS      20
+#define MAX_STREAM_BUF_CNT       10
+#define STREAM_BUF_CNT (10)
+#define DVB_MAX_PAYLOAD_PACKET_SIZE 4096
+#define STREAM_BUF_SIZ (DVB_MAX_PAYLOAD_PACKET_SIZE)
+#include <linux/dvb/frontend.h>
+#endif
+
+/**
+ * @file dvb-vb2.h
+ * @ingroup frontend_scan
+ * @brief Provides interfaces to videobuf2 streaming for DVB.
+ * @copyright GNU Lesser General Public License version 2.1 (LGPLv2.1)
+ * @author Satendra Singh Thakur
+ *
+ * @par Bug Report
+ * Please submit bug reports and patches to linux-media@vger.kernel.org
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**Max count of the buffers*/
+#define MAX_STREAM_BUF_CNT	10
+
+/**
+ * struct stream_ctx - Streaming context
+ *
+ * @param in_fd		File descriptor of streaming device
+ * @param buf_cnt	Count of the buffers to be queued/dequeued
+ * @param buf_size	Size of one such buffer
+ * @param buf		Pointer to array of buffers
+ * @param buf_flags	Array of boolean flags corresponding to buffers
+ * @param exp_fd	Array of file descriptors of exported buffers
+ * @param error		Error flag
+ */
+struct stream_ctx {
+	int in_fd;
+	int buf_cnt;
+	int buf_size;
+	unsigned char *buf[MAX_STREAM_BUF_CNT];
+	int buf_flag[MAX_STREAM_BUF_CNT];
+	int exp_fd[MAX_STREAM_BUF_CNT];
+	int error;
+};
+/**
+ * stream_qbuf - Enqueues a buffer specified by index n
+ *
+ * @param sc		Context for streaming management
+ *			Pointer to &struct stream_ctx
+ * @param idx		Index of the buffer
+ *
+ * @return At return, it returns a negative value if error or
+ * zero on success.
+ */
+int stream_qbuf(struct stream_ctx *sc, int idx);
+
+/**
+ * sream_dqbuf - Dequeues a buffer specified by buf argument
+ *
+ * @param sc		Context for streaming management
+ *			Pointer to &struct stream_ctx
+ * @param buf		Pointer to &struct dmx_buffer
+ *
+ * @return At return, it returns a negative value if error or
+ * zero on success.
+ */
+int stream_dqbuf(struct stream_ctx *sc,
+		 struct dmx_buffer *buf);
+/**
+ * sream_expbuf - Exports a buffer specified by buf argument
+ *
+ * @param sc		Context for streaming management
+ *			Pointer to &struct stream_ctx
+ * @param idx		Index of the buffer
+ *
+ * @return At return, it returns a negative value if error or
+ * zero on success.
+ */
+int stream_expbuf(struct stream_ctx *sc,
+		  int idx);
+/**
+ * stream_init - Requests number of buffers from memory
+ * Gets pointer to the buffers from driver, mmaps those buffers
+ * and stores them in an array
+ * Also, optionally exports those buffers
+ *
+ * @param sc		Context for streaming management
+ * @param in_fd		File descriptor of the streaming device
+ * @param buf_size	Size of the buffer
+ * @param buf_cnt	Number of buffers
+ *
+ * @return At return, it returns a negative value if error or
+ * zero on success.
+ */
+int stream_init(struct stream_ctx *sc,
+		int in_fd, int buf_size, int buf_cnt);
+
+/**
+ * @struct dvb_table_filter
+ * @brief De-initiazes streaming
+ * @ingroup frontend_scan
+ *
+ * @param sc		Pointer to &struct stream_ctx
+ */
+void stream_deinit(struct stream_ctx *sc);
+/**
+ * stream_to_file - Implements enqueue and dequeue logic
+ * First enqueues all the available buffers then dequeues
+ * one buffer, again enqueues it and so on.
+ *
+ * @param in_fd		File descriptor of the streaming device
+ * @param out_fd	File descriptor of output file
+ * @param timeout	Timeout in seconds
+ * @param dbg_level	Debug flag
+ * @param exit_flag	Flag to exit
+ *
+ * @return void
+ */
+void stream_to_file(struct dvb_v5_fe_parms *parms, int in_fd, int out_fd,
+		    int timeout, int dbg_level, int *exit_flag);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libdvbtee/dvbtee_config.h
+++ b/libdvbtee/dvbtee_config.h
@@ -29,6 +29,39 @@
 #ifdef HAVE_LINUX_DVB_FRONTEND_H
 #if HAVE_LINUX_DVB_FRONTEND_H
 #define USE_LINUXTV
+#include <linux/dvb/dmx.h>
+#ifndef DMX_DQBUF
+#include <stdint.h>
+struct dmx_buffer {
+	uint32_t			index;
+	uint32_t			bytesused;
+	uint32_t			offset;
+	uint32_t			length;
+	uint32_t			flags;
+	uint32_t			count;
+};
+struct dmx_requestbuffers {
+	uint32_t			count;
+	uint32_t			size;
+};
+struct dmx_exportbuffer {
+	uint32_t		index;
+	uint32_t		flags;
+	uint32_t		fd;
+};
+enum dmx_buffer_flags {
+	DMX_BUFFER_FLAG_HAD_CRC32_DISCARD		= 1 << 0,
+	DMX_BUFFER_FLAG_TEI				= 1 << 1,
+	DMX_BUFFER_PKT_COUNTER_MISMATCH			= 1 << 2,
+	DMX_BUFFER_FLAG_DISCONTINUITY_DETECTED		= 1 << 3,
+	DMX_BUFFER_FLAG_DISCONTINUITY_INDICATOR		= 1 << 4,
+};
+#define DMX_REQBUFS              _IOWR('o', 60, struct dmx_requestbuffers)
+#define DMX_QUERYBUF             _IOWR('o', 61, struct dmx_buffer)
+#define DMX_EXPBUF               _IOWR('o', 62, struct dmx_exportbuffer)
+#define DMX_QBUF                 _IOWR('o', 63, struct dmx_buffer)
+#define DMX_DQBUF                _IOWR('o', 64, struct dmx_buffer)
+#endif
 #endif
 #endif
 

--- a/libdvbtee/linuxtv_tuner.cpp
+++ b/libdvbtee/linuxtv_tuner.cpp
@@ -398,7 +398,8 @@ int linuxtv_tuner::start_feed()
 	sc = new stream_ctx;
 	ret = stream_init(sc, demux_fd, 10, (188*(4096/188)));
 	if (ret < 0) {
-		perror("stream_init failed");//: error %d, %s\n", errno, strerror(errno));
+		// DMX_REQBUFS / mmap() failed?  failover to using read()
+		//perror("stream_init failed");//: error %d, %s\n", errno, strerror(errno));
 		goto fail_mmap;
 	}
 

--- a/libdvbtee/linuxtv_tuner.cpp
+++ b/libdvbtee/linuxtv_tuner.cpp
@@ -398,8 +398,6 @@ int linuxtv_tuner::start_feed()
 	sc = new stream_ctx;
 	ret = stream_init(sc, demux_fd, 10, (188*(4096/188)));
 	if (ret < 0) {
-		delete sc;
-		sc = NULL;
 		perror("stream_init failed");//: error %d, %s\n", errno, strerror(errno));
 		goto fail_mmap;
 	}
@@ -411,6 +409,8 @@ int linuxtv_tuner::start_feed()
 
 fail_mmap:
 	stream_deinit(sc);
+	delete sc;
+	sc = NULL;
 
 	memset(&pesfilter, 0, sizeof(pesfilter));
 

--- a/libdvbtee/linuxtv_tuner.cpp
+++ b/libdvbtee/linuxtv_tuner.cpp
@@ -396,7 +396,7 @@ int linuxtv_tuner::start_feed()
 	sleep(1); // FIXME
 
 	sc = new stream_ctx;
-	ret = stream_init(sc, demux_fd, STREAM_BUF_CNT, (188*(4096/188)));
+	ret = stream_init(sc, demux_fd, 10, (188*(4096/188)));
 	if (ret < 0) {
 		delete sc;
 		sc = NULL;

--- a/libdvbtee/linuxtv_tuner.cpp
+++ b/libdvbtee/linuxtv_tuner.cpp
@@ -396,7 +396,7 @@ int linuxtv_tuner::start_feed()
 	sleep(1); // FIXME
 
 	sc = new stream_ctx;
-	ret = stream_init(sc, demux_fd, 10, (188*(4096/188)));
+	ret = stream_init(sc, demux_fd, MAX_STREAM_BUF_CNT, (188*(4096/188)));
 	if (ret < 0) {
 		// DMX_REQBUFS / mmap() failed?  failover to using read()
 		//perror("stream_init failed");//: error %d, %s\n", errno, strerror(errno));

--- a/libdvbtee/linuxtv_tuner.h
+++ b/libdvbtee/linuxtv_tuner.h
@@ -23,6 +23,7 @@
 #define __LINUXTV_TUNER_H__
 
 #include "tune.h"
+#include "dvb-vb2.h"
 
 #if 0
 #include <map>
@@ -33,7 +34,7 @@ static map_chan_to_ts_id channels;
 typedef std::map<uint16_t, int> filtered_pid_map; /* pid, fd */
 typedef std::map<unsigned int, bool> channel_map; /* channel, found? */
 
-class linuxtv_tuner: public tune, public tsfilter_iface
+class linuxtv_tuner: public tune, public tsfilter_iface, public feed_pull_iface
 {
 public:
 	linuxtv_tuner();
@@ -55,6 +56,8 @@ public:
 	bool check();
 
 	void addfilter(uint16_t);
+
+	int pull();
 private:
 	void add_filter(uint16_t);
 	void clear_filters();
@@ -82,6 +85,8 @@ private:
 	filtered_pid_map filtered_pids;
 
 	int open_available_tuner(unsigned int max_adap = 8, unsigned int max_fe = 3);
+
+	stream_ctx *sc;
 };
 
 #endif /*__LINUXTV_TUNER_H__ */


### PR DESCRIPTION
Avoid a copy using `mmap()` from the `demux` device rather than `read()` from the `dvr` device.

Depends on `dvb-mmap` support in linux kernel 4.16.x or later.

Tested in Linux Kernel 4.16.2, backwards compat tested in Linux Kernel 4.13

Signed-off-by: Michael Ira Krufky <mkrufky@linuxtv.org>