### PR TITLE
Detect encoding of DVB descriptor text fields

### DIFF
--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -60,17 +60,23 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("lang", std::string((const char*)lang));
 
 	size_t prefix;
-	const char *encoding = detect_encoding(encoded_text, &prefix);
+	const char *encoding = detect_encoding((unsigned char *)encoded_text, &prefix);
 	unsigned char *name;
 	unsigned char *text;
 	if (encoding) {
-		set("original_encoding", std::string(encoding));
+		set("original_text_encoding", std::string((const char *)encoding));
 
-		name = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_name, encoding) : encoded_name;
 		text = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_text, encoding) : encoded_text;
 	} else {
-		name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
 		text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
+	}
+	encoding = detect_encoding((unsigned char *)encoded_name, &prefix);
+	if (encoding) {
+		set("original_name_encoding", std::string((const char *)encoding));
+
+		name = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_name, encoding) : encoded_name;
+	} else {
+		name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
 	}
 
 	/* FIXME: we should escape these strings on output rather than on store */

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -59,8 +59,8 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 
 	set("lang", std::string((const char*)lang));
 
-	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
+	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_auto((char *)encoded_name) : encoded_name;
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_auto((char *)encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)name, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -59,8 +59,12 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 
 	set("lang", std::string((const char*)lang));
 
+/*
 	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
 	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
+*/
+	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_iso8859((char *)encoded_name) : encoded_name;
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso8859((char *)encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)name, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -59,25 +59,8 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 
 	set("lang", std::string((const char*)lang));
 
-	size_t prefix;
-	const char *encoding = detect_encoding((unsigned char *)encoded_text, &prefix);
-	unsigned char *name;
-	unsigned char *text;
-	if (encoding) {
-		set("original_text_encoding", std::string((const char *)encoding));
-
-		text = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_text, encoding) : encoded_text;
-	} else {
-		text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
-	}
-	encoding = detect_encoding((unsigned char *)encoded_name, &prefix);
-	if (encoding) {
-		set("original_name_encoding", std::string((const char *)encoding));
-
-		name = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_name, encoding) : encoded_name;
-	} else {
-		name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
-	}
+	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)name, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -59,8 +59,8 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 
 	set("lang", std::string((const char*)lang));
 
-	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_auto((char *)encoded_name) : encoded_name;
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_auto((char *)encoded_text) : encoded_text;
+	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_auto(encoded_name) : encoded_name;
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_auto(encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)name, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4d.cpp
+++ b/libdvbtee/decode/descriptor/desc_4d.cpp
@@ -59,12 +59,19 @@ desc_4d::desc_4d(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 
 	set("lang", std::string((const char*)lang));
 
-/*
-	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
-*/
-	unsigned char *name = (b_translate_iso6937) ? (unsigned char *)translate_iso8859((char *)encoded_name) : encoded_name;
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso8859((char *)encoded_text) : encoded_text;
+	size_t prefix;
+	const char *encoding = detect_encoding(encoded_text, &prefix);
+	unsigned char *name;
+	unsigned char *text;
+	if (encoding) {
+		set("original_encoding", std::string(encoding));
+
+		name = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_name, encoding) : encoded_name;
+		text = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_text, encoding) : encoded_text;
+	} else {
+		name = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_name) : encoded_name;
+		text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
+	}
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)name, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -59,10 +59,16 @@ desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("last_descriptor_number", dr->i_last_descriptor_number);
 	set("lang", std::string((const char*)lang));
 
-/*
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
-*/
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso8859((char *)encoded_text) : encoded_text;
+	size_t prefix;
+	const char *encoding = detect_encoding(encoded_text, &prefix);
+	unsigned char *text;
+	if (encoding) {
+		set("original_encoding", std::string(encoding));
+
+		text = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_text, encoding) : encoded_text;
+	} else {
+		text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
+	}
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)text, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -60,10 +60,10 @@ desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("lang", std::string((const char*)lang));
 
 	size_t prefix;
-	const char *encoding = detect_encoding(encoded_text, &prefix);
+	const char *encoding = detect_encoding((unsigned char *)encoded_text, &prefix);
 	unsigned char *text;
 	if (encoding) {
-		set("original_encoding", std::string(encoding));
+		set("original_encoding", std::string((const char *)encoding));
 
 		text = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_text, encoding) : encoded_text;
 	} else {

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -59,7 +59,10 @@ desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("last_descriptor_number", dr->i_last_descriptor_number);
 	set("lang", std::string((const char*)lang));
 
+/*
 	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
+*/
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso8859((char *)encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)text, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -59,7 +59,7 @@ desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("last_descriptor_number", dr->i_last_descriptor_number);
 	set("lang", std::string((const char*)lang));
 
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_auto((char *)encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)text, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -59,16 +59,7 @@ desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("last_descriptor_number", dr->i_last_descriptor_number);
 	set("lang", std::string((const char*)lang));
 
-	size_t prefix;
-	const char *encoding = detect_encoding((unsigned char *)encoded_text, &prefix);
-	unsigned char *text;
-	if (encoding) {
-		set("original_encoding", std::string((const char *)encoding));
-
-		text = (b_translate_iso6937) ? (unsigned char *)translate((char *)encoded_text, encoding) : encoded_text;
-	} else {
-		text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
-	}
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_iso6937((char *)encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)text, '"')) {

--- a/libdvbtee/decode/descriptor/desc_4e.cpp
+++ b/libdvbtee/decode/descriptor/desc_4e.cpp
@@ -59,7 +59,7 @@ desc_4e::desc_4e(Decoder *parent, dvbpsi_descriptor_t *p_descriptor)
 	set("last_descriptor_number", dr->i_last_descriptor_number);
 	set("lang", std::string((const char*)lang));
 
-	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_auto((char *)encoded_text) : encoded_text;
+	unsigned char *text = (b_translate_iso6937) ? (unsigned char *)translate_auto(encoded_text) : encoded_text;
 
 	/* FIXME: we should escape these strings on output rather than on store */
 	if (strchr((char*)text, '"')) {

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -368,6 +368,7 @@ const char *__detect_encoding(unsigned char *input, size_t *prefix) {
     case 0x13: return "gb2312";
     case 0x14: return "iso-10646-1";
   }
+  *prefix = 0;
   return NULL;
 }
 

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -378,6 +378,7 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
     case 0x11: return "ucs-2";
     case 0x12: return "KSC_5601";
     case 0x13: return "gb2312";
+    case 0x14: return "iso-10646-1";
   }
   return NULL;
 }

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -306,9 +306,9 @@ char *escape_quotes(const char *str) {
 	return buf;
 }
 
-/* Translate ISO6937 encoded string into UTF-8 */
+/* Translate encoded string into UTF-8 */
 /* IMPORTANT: be sure to free() the returned string after use */
-char *translate_iso6937(char *str) {
+char *translate(char *str, char *encoding) {
     size_t iconv_in_s = strlen((const char *)str);
     size_t iconv_out_s = iconv_in_s * 6 + 1;
 
@@ -317,26 +317,21 @@ char *translate_iso6937(char *str) {
     char *iconv_in = (char *) &str[0];
     char *iconv_out = (char *) &out[0];
 
-    iconv_t conv = iconv_open("UTF-8", "ISO6937");
+    iconv_t conv = iconv_open("UTF-8", encoding);
     iconv(conv, &iconv_in, &iconv_in_s, &iconv_out, &iconv_out_s);
     iconv_close(conv);
 
     return out;
 }
 
+/* Translate ISO6937 encoded string into UTF-8 */
+/* IMPORTANT: be sure to free() the returned string after use */
+char *translate_iso6937(char *str) {
+    return translate(str, "ISO6937");
+}
+
 /* Translate ISO8859 encoded string into UTF-8 */
 /* IMPORTANT: be sure to free() the returned string after use */
 char *translate_iso8859(char *str) {
-    char *out = (char *)calloc(sizeof(char), strlen((const char *)str) * 6 + 1);
-
-    char *iconv_in = (char *) &str[0];
-    char *iconv_out = (char *) &out[0];
-    size_t iconv_in_s = strlen((const char *)str);
-    size_t iconv_out_s = iconv_in_s * 6 + 1;
-
-    iconv_t conv = iconv_open("UTF-8", "ISO8859");
-    iconv(conv, &iconv_in, &iconv_in_s, &iconv_out, &iconv_out_s);
-    iconv_close(conv);
-
-    return out;
+    return translate(str, "ISO8859");
 }

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -391,8 +391,8 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
   const char *ret = __detect_encoding(input, prefix);
   printf("\ndetect encoding: %c %c %c from: %s, %lu returns %s\n",
     input[0], input[1], input[2], input, *prefix, ret);
-  //return ret;
-  return  "iso-8859-5";
+  return ret;
+  //return  "iso-8859-5";
 }
 
 

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -324,22 +324,6 @@ char *translate(char *str, const char *encoding) {
     return out;
 }
 
-char *translate_auto(char *str);
-
-/* Translate ISO6937 encoded string into UTF-8 */
-/* IMPORTANT: be sure to free() the returned string after use */
-char *translate_iso6937(char *str) {
-	return translate_auto(str);
-//    return translate(str, "ISO6937");
-}
-
-/* Translate ISO8859 encoded string into UTF-8 */
-/* IMPORTANT: be sure to free() the returned string after use */
-char *translate_iso8859(char *str) {
-	return translate_auto(str);
-//    return translate(str, "ISO8859");
-}
-
 /* Thanks to Aman Gupta:
  * https://github.com/mkrufky/node-dvbtee/issues/25#issuecomment-391823070
  */
@@ -392,10 +376,10 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
   printf("\ndetect encoding: %c %c %c from: %s, %lu returns %s\n",
     input[0], input[1], input[2], input, *prefix, ret);
   return ret;
-  //return  "iso-8859-5";
 }
 
-
+/* Translate encoded string into UTF-8 */
+/* IMPORTANT: be sure to free() the returned string after use */
 char *translate_auto(char *str) {
 	size_t prefix;
 	const char *encoding = detect_encoding((unsigned char *)str, &prefix);

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -308,7 +308,7 @@ char *escape_quotes(const char *str) {
 
 /* Translate encoded string into UTF-8 */
 /* IMPORTANT: be sure to free() the returned string after use */
-char *translate(char *str, char *encoding) {
+char *translate(char *str, const char *encoding) {
     size_t iconv_in_s = strlen((const char *)str);
     size_t iconv_out_s = iconv_in_s * 6 + 1;
 
@@ -334,4 +334,50 @@ char *translate_iso6937(char *str) {
 /* IMPORTANT: be sure to free() the returned string after use */
 char *translate_iso8859(char *str) {
     return translate(str, "ISO8859");
+}
+
+/* Thanks to Aman Gupta:
+ * https://github.com/mkrufky/node-dvbtee/issues/25#issuecomment-391823070
+ */
+const char *detect_encoding(unsigned char *input, size_t *prefix) {
+  *prefix = 0;
+  if (input[0] >= 0x20) return NULL;
+  if (input[0] == 0x10 && input[1] == 0x0) {
+    *prefix = 3;
+    switch (input[2]) {
+      case 0x01: return "iso-8859-1";
+      case 0x02: return "iso-8859-2";
+      case 0x03: return "iso-8859-3";
+      case 0x04: return "iso-8859-4";
+      case 0x05: return "iso-8859-5";
+      case 0x06: return "iso-8859-6";
+      case 0x07: return "iso-8859-7";
+      case 0x08: return "iso-8859-8";
+      case 0x09: return "iso-8859-9";
+      case 0x0a: return "iso-8859-10";
+      case 0x0b: return "iso-8859-11";
+      case 0x0c: return "iso-8859-12";
+      case 0x0d: return "iso-8859-13";
+      case 0x0e: return "iso-8859-14";
+      case 0x0f: return "iso-8859-15";
+    }
+  }
+  *prefix = 1;
+  switch (input[0]) {
+    case 0x01: return "iso-8859-5";
+    case 0x02: return "iso-8859-6";
+    case 0x03: return "iso-8859-7";
+    case 0x04: return "iso-8859-8";
+    case 0x05: return "iso-8859-9";
+    case 0x06: return "iso-8859-10";
+    case 0x07: return "iso-8859-11";
+    case 0x08: return NULL;
+    case 0x09: return "iso-8859-13";
+    case 0x0a: return "iso-8859-14";
+    case 0x0b: return "iso-8859-15";
+    case 0x11: return "ucs-2";
+    case 0x12: return "KSC_5601";
+    case 0x13: return "gb2312";
+  }
+  return NULL;
 }

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -85,10 +85,7 @@ unsigned char* get_descriptor_text(unsigned char* desc, uint8_t len, unsigned ch
 {
 	unsigned char* p = text;
 	for (int i = 0; i < len; i++, desc++) {
-		if (*desc == ':')
-			*text++ = ' ';
-		else if (*desc >= 0x20 && (*desc < 0x80 || *desc > 0x9f))
-			*text++ = *desc;
+		*text++ = *desc;
 	}
 	*text = 0;
 	return p;

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -83,12 +83,9 @@ void dump_descriptors(const char* str, dvbpsi_descriptor_t* descriptors)
 
 unsigned char* get_descriptor_text(unsigned char* desc, uint8_t len, unsigned char* text)
 {
-	unsigned char* p = text;
-	for (int i = 0; i < len; i++, desc++) {
-		*text++ = *desc;
-	}
-	*text = 0;
-	return p;
+	memcpy(text, desc, len);
+	text[len] = 0;
+	return text;
 }
 
 //-----------------------------------------------------------------------------

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -357,10 +357,11 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
     case 0x09: return "iso-8859-13";
     case 0x0a: return "iso-8859-14";
     case 0x0b: return "iso-8859-15";
-    case 0x11: return "ucs-2";
-    case 0x12: return "KSC_5601";
-    case 0x13: return "gb2312";
-    case 0x14: return "iso-10646-1";
+    case 0x11: return "ucs-2";       /* "iso-10646-1" ? Basic Multilingual Plane of ISO/IEC 10646-1 */
+    case 0x12: return "KSC_5601";    /* "KSC5601-1987" */
+    case 0x13: return "gb2312";      /* "GB-2312-1980" */
+    case 0x14: return "iso-10646-1"; /* Big5 subset of ISO/IEC 10646-1 */
+    case 0x15: return "utf-8";
   }
   *prefix = 0;
   return NULL;

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -308,7 +308,7 @@ char *escape_quotes(const char *str) {
 
 /* Translate encoded string into UTF-8 */
 /* IMPORTANT: be sure to free() the returned string after use */
-char *translate(char *str, const char *encoding) {
+char *translate(unsigned char *str, const char *encoding) {
     size_t iconv_in_s = strlen((const char *)str);
     size_t iconv_out_s = iconv_in_s * 6 + 1;
 
@@ -380,8 +380,8 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
 
 /* Translate encoded string into UTF-8 */
 /* IMPORTANT: be sure to free() the returned string after use */
-char *translate_auto(char *str) {
+char *translate_auto(unsigned char *str) {
 	size_t prefix;
-	const char *encoding = detect_encoding((unsigned char *)str, &prefix);
+	const char *encoding = detect_encoding(str, &prefix);
 	return translate(&str[prefix], encoding ? encoding :"ISO6937");
 }

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -371,5 +371,6 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
 char *translate_auto(unsigned char *str) {
 	size_t prefix;
 	const char *encoding = detect_encoding(str, &prefix);
-	return translate(&str[prefix], encoding ? encoding :"ISO6937");
+	/* We used to use "ISO6937" by default, but "iso-8859-1" seems much better */
+	return translate(&str[prefix], encoding ? encoding : "iso-8859-1");
 }

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -353,7 +353,7 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
     case 0x05: return "iso-8859-9";
     case 0x06: return "iso-8859-10";
     case 0x07: return "iso-8859-11";
-    case 0x08: return NULL;
+    case 0x08: return "iso-8859-12";
     case 0x09: return "iso-8859-13";
     case 0x0a: return "iso-8859-14";
     case 0x0b: return "iso-8859-15";

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -324,22 +324,26 @@ char *translate(char *str, const char *encoding) {
     return out;
 }
 
+char *translate_auto(char *str);
+
 /* Translate ISO6937 encoded string into UTF-8 */
 /* IMPORTANT: be sure to free() the returned string after use */
 char *translate_iso6937(char *str) {
-    return translate(str, "ISO6937");
+	return translate_auto(str);
+//    return translate(str, "ISO6937");
 }
 
 /* Translate ISO8859 encoded string into UTF-8 */
 /* IMPORTANT: be sure to free() the returned string after use */
 char *translate_iso8859(char *str) {
-    return translate(str, "ISO8859");
+	return translate_auto(str);
+//    return translate(str, "ISO8859");
 }
 
 /* Thanks to Aman Gupta:
  * https://github.com/mkrufky/node-dvbtee/issues/25#issuecomment-391823070
  */
-const char *detect_encoding(unsigned char *input, size_t *prefix) {
+const char *__detect_encoding(unsigned char *input, size_t *prefix) {
   *prefix = 0;
   if (input[0] >= 0x20) return NULL;
   if (input[0] == 0x10 && input[1] == 0x0) {
@@ -381,4 +385,19 @@ const char *detect_encoding(unsigned char *input, size_t *prefix) {
     case 0x14: return "iso-10646-1";
   }
   return NULL;
+}
+
+const char *detect_encoding(unsigned char *input, size_t *prefix) {
+  const char *ret = __detect_encoding(input, prefix);
+  printf("\ndetect encoding: %c %c %c from: %s, %lu returns %s\n",
+    input[0], input[1], input[2], input, *prefix, ret);
+  //return ret;
+  return  "iso-8859-5";
+}
+
+
+char *translate_auto(char *str) {
+	size_t prefix;
+	const char *encoding = detect_encoding((unsigned char *)str, &prefix);
+	return translate(&str[prefix], encoding ? encoding :"ISO6937");
 }

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -327,7 +327,7 @@ char *translate(unsigned char *str, const char *encoding) {
 /* Thanks to Aman Gupta:
  * https://github.com/mkrufky/node-dvbtee/issues/25#issuecomment-391823070
  */
-const char *__detect_encoding(unsigned char *input, size_t *prefix) {
+const char *detect_encoding(unsigned char *input, size_t *prefix) {
   *prefix = 0;
   if (input[0] >= 0x20) return NULL;
   if (input[0] == 0x10 && input[1] == 0x0) {
@@ -370,13 +370,6 @@ const char *__detect_encoding(unsigned char *input, size_t *prefix) {
   }
   *prefix = 0;
   return NULL;
-}
-
-const char *detect_encoding(unsigned char *input, size_t *prefix) {
-  const char *ret = __detect_encoding(input, prefix);
-  printf("\ndetect encoding: %c %c %c from: %s, %lu returns %s\n",
-    input[0], input[1], input[2], input, *prefix, ret);
-  return ret;
 }
 
 /* Translate encoded string into UTF-8 */

--- a/libdvbtee/functions.cpp
+++ b/libdvbtee/functions.cpp
@@ -323,3 +323,20 @@ char *translate_iso6937(char *str) {
 
     return out;
 }
+
+/* Translate ISO8859 encoded string into UTF-8 */
+/* IMPORTANT: be sure to free() the returned string after use */
+char *translate_iso8859(char *str) {
+    char *out = (char *)calloc(sizeof(char), strlen((const char *)str) * 6 + 1);
+
+    char *iconv_in = (char *) &str[0];
+    char *iconv_out = (char *) &out[0];
+    size_t iconv_in_s = strlen((const char *)str);
+    size_t iconv_out_s = iconv_in_s * 6 + 1;
+
+    iconv_t conv = iconv_open("UTF-8", "ISO8859");
+    iconv(conv, &iconv_in, &iconv_in_s, &iconv_out, &iconv_out_s);
+    iconv_close(conv);
+
+    return out;
+}

--- a/libdvbtee/functions.h
+++ b/libdvbtee/functions.h
@@ -88,5 +88,6 @@ int decode_multiple_string(const uint8_t* data, uint8_t len, unsigned char* text
 char *url_encode(const char *str);
 char *escape_quotes(const char *str);
 char *translate_iso6937(char *str);
+char *translate_iso8859(char *str);
 
 #endif /* __FUNCTIONS_H__ */

--- a/libdvbtee/functions.h
+++ b/libdvbtee/functions.h
@@ -87,8 +87,6 @@ int decode_multiple_string(const uint8_t* data, uint8_t len, unsigned char* text
 
 char *url_encode(const char *str);
 char *escape_quotes(const char *str);
-char *translate(char *str, const char *encoding);
 char *translate_auto(char *str);
-const char *detect_encoding(unsigned char *input, size_t *prefix);
 
 #endif /* __FUNCTIONS_H__ */

--- a/libdvbtee/functions.h
+++ b/libdvbtee/functions.h
@@ -88,8 +88,7 @@ int decode_multiple_string(const uint8_t* data, uint8_t len, unsigned char* text
 char *url_encode(const char *str);
 char *escape_quotes(const char *str);
 char *translate(char *str, const char *encoding);
-char *translate_iso6937(char *str);
-char *translate_iso8859(char *str);
+char *translate_auto(char *str);
 const char *detect_encoding(unsigned char *input, size_t *prefix);
 
 #endif /* __FUNCTIONS_H__ */

--- a/libdvbtee/functions.h
+++ b/libdvbtee/functions.h
@@ -87,6 +87,6 @@ int decode_multiple_string(const uint8_t* data, uint8_t len, unsigned char* text
 
 char *url_encode(const char *str);
 char *escape_quotes(const char *str);
-char *translate_auto(char *str);
+char *translate_auto(unsigned char *str);
 
 #endif /* __FUNCTIONS_H__ */

--- a/libdvbtee/functions.h
+++ b/libdvbtee/functions.h
@@ -87,8 +87,9 @@ int decode_multiple_string(const uint8_t* data, uint8_t len, unsigned char* text
 
 char *url_encode(const char *str);
 char *escape_quotes(const char *str);
-char *translate(char *str, char *encoding);
+char *translate(char *str, const char *encoding);
 char *translate_iso6937(char *str);
 char *translate_iso8859(char *str);
+const char *detect_encoding(unsigned char *input, size_t *prefix);
 
 #endif /* __FUNCTIONS_H__ */

--- a/libdvbtee/functions.h
+++ b/libdvbtee/functions.h
@@ -87,6 +87,7 @@ int decode_multiple_string(const uint8_t* data, uint8_t len, unsigned char* text
 
 char *url_encode(const char *str);
 char *escape_quotes(const char *str);
+char *translate(char *str, char *encoding);
 char *translate_iso6937(char *str);
 char *translate_iso8859(char *str);
 


### PR DESCRIPTION
I believe this may be a step in the right direction towards the proper fix for #29 and also https://github.com/mkrufky/node-dvbtee/issues/25

libdvbtee always uses the ISO6937 decoder even when it should be using ISO8859.  We should be able to detect the proper encoding and use it accordingly, as per the spec:

http://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.05.01_40/en_300468v010501o.pdf

> Text fields can optionally start with non-spacing, non-displayed data which specifies the alternative character table to be used for the remainder of the text item. The selection of character table is indicated as follows: 
> 
> - if the first byte of the text field has a value in the range "0x20" to "0xFF" then this and all subsequent bytes in the text item are coded using the default character coding table (table 00 - Latin alphabet) of figure A.1; 
> 
> - if the first byte of the text field has a value in the range "0x01" to "0x0F" then the remaining bytes in the text item are coded in accordance with the character coding tables which are given in table A.3; 
> 
> - if the first byte of the text field has a value "0x10" then the following two bytes carry a 16-bit value (uimsbf) N to indicate that the remaining data of the text field is coded using the character code table specified by ISO Standard 8859, parts 1 to 9; 
> 
> - if the first byte of the text field has a value "0x11" then the remaining bytes in the text item are coded in pairs in accordance with the Basic Multilingual Plane of ISO/IEC 10646-1 [8]; 
> 
> - if the first byte of the text field has a value "0x12" then the remaining bytes in the text item are coded in accordance with the Korean Character Set KSC5601-1987 [18]; 
> 
> - if the first byte of the text field has a value "0x13" then the remaining bytes in the text item are coded in accordance with the Simplified Chinese Character Set GB-2312-1980; 
> 
> - if the first byte of the text field has a value "0x14" then the remaining bytes in the text item are coded in accordance with the Big5 subset of ISO/IEC 10646-1 [8] for use with Traditional Chinese. 
> 
> Values for the first byte of "0x15" to "0x1F" are reserved for future use. 

closes #29 